### PR TITLE
Increment always returns the numerical value of the counter

### DIFF
--- a/lib/active_support/cache/redis_cluster_store.rb
+++ b/lib/active_support/cache/redis_cluster_store.rb
@@ -36,10 +36,11 @@ module ActiveSupport
         instrument(:increment, key, :amount => amount) do
           with do |c|
             if ttl
-              c.pipelined do
+              new_value, _ = c.pipelined do
                 c.incrby normalized_key, amount
                 c.expire normalized_key, ttl
               end
+              new_value
             else
               c.incrby normalized_key, amount
             end

--- a/redis-cluster-activesupport.gemspec
+++ b/redis-cluster-activesupport.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "redis-activesupport"
-  spec.add_development_dependency "pry"
   spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "fakeredis"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "pry"
 require "redis/cluster/activesupport"
+require "fakeredis/rspec"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Bug identified while using `rack-attack` and seeing the following error:

```
NoMethodError: undefined method `>' for [1, true]:Array
```

NOTE: I dropped in the fake redis gem instead of my `double()` which will actually test real redis-like responses. Doing this sooner would have helped identify the breaking change to the interface.

cc @liveh2o