### PR TITLE
use redis.with for rails >= 6.0 and < 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       RAILS_ENV: test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Add or replace dependency steps here
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
       matrix:
         ruby-version: [ '3.2', '3.1', '3.0', '2.7', '2.6', 'jruby-9.3', 'jruby-9.4' ]
         gemfile: [ 'rails60', 'rails61' ]
-    env:
+    env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       RAILS_ENV: test
     steps:
       - name: Checkout code
@@ -28,8 +29,6 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby-version }}
-        env:
-          BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       # Add or replace test runners here
       - name: Run tests
         run: bundle exec rspec

--- a/gemfiles/rails60.gemfile.lock
+++ b/gemfiles/rails60.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    redis-cluster-activesupport (0.3.0)
-      activesupport (~> 6.0)
+    redis-cluster-activesupport (1.0.0)
+      activesupport (>= 6.0, < 7.1)
 
 GEM
   remote: https://rubygems.org/
@@ -14,15 +14,15 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     coderay (1.1.3)
-    concurrent-ruby (1.2.0)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
-    fakeredis (0.8.0)
-      redis (~> 4.1)
-    ffi (1.15.5-java)
-    i18n (1.12.0)
+    fakeredis (0.9.2)
+      redis (~> 4.8)
+    ffi (1.16.3-java)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.17.0)
+    minitest (5.20.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -31,29 +31,30 @@ GEM
       method_source (~> 1.0)
       spoon (~> 0.0)
     rake (10.5.0)
-    redis (4.8.0)
+    redis (4.8.1)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.1)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.2)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.3)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
     spoon (0.0.6)
       ffi
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
-    zeitwerk (2.6.6)
+    zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-22
   universal-java-1.8
   universal-java-11
   x86_64-linux
@@ -68,4 +69,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.4.6
+   2.4.20

--- a/gemfiles/rails61.gemfile.lock
+++ b/gemfiles/rails61.gemfile.lock
@@ -1,28 +1,28 @@
 PATH
   remote: ..
   specs:
-    redis-cluster-activesupport (0.3.0)
-      activesupport (~> 6.0)
+    redis-cluster-activesupport (1.0.0)
+      activesupport (>= 6.0, < 7.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.7.2)
+    activesupport (6.1.7.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     coderay (1.1.3)
-    concurrent-ruby (1.2.0)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
-    fakeredis (0.8.0)
-      redis (~> 4.1)
-    ffi (1.15.5-java)
-    i18n (1.12.0)
+    fakeredis (0.9.2)
+      redis (~> 4.8)
+    ffi (1.16.3-java)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.17.0)
+    minitest (5.20.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -31,27 +31,28 @@ GEM
       method_source (~> 1.0)
       spoon (~> 0.0)
     rake (10.5.0)
-    redis (4.8.0)
+    redis (4.8.1)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.1)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.2)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.3)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
     spoon (0.0.6)
       ffi
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.6)
+    zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-22
   universal-java-1.8
   universal-java-11
   x86_64-linux
@@ -66,4 +67,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.4.6
+   2.4.20

--- a/lib/active_support/cache/redis_cluster_store.rb
+++ b/lib/active_support/cache/redis_cluster_store.rb
@@ -16,7 +16,7 @@ module ActiveSupport
         ttl = _expires_in(options)
         normalized_key = normalize_key(key, options)
         instrument(:increment, key, :amount => amount) do
-          with do |c|
+          redis.with do |c|
             if ttl
               new_value, _ = c.pipelined do
                 c.incrby normalized_key, amount

--- a/redis-cluster-activesupport.gemspec
+++ b/redis-cluster-activesupport.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "~> 6.0"
+  spec.add_dependency "activesupport", ">= 6.0", "< 7.1"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "fakeredis"
   spec.add_development_dependency "pry"

--- a/spec/active_support/cache/redis_cluster_store_spec.rb
+++ b/spec/active_support/cache/redis_cluster_store_spec.rb
@@ -20,7 +20,7 @@ describe ::ActiveSupport::Cache::RedisClusterStore do
 
   describe "#increment" do
     let(:fake_client) { Redis.new }
-    before { allow(subject).to receive(:with).and_yield(fake_client) }
+    before { allow(subject).to receive(:redis).and_return(fake_client) }
 
     it "only returns the new value after being incremented with ttl" do
       expect(subject.increment("testing", 1, :expires_in => 5.minutes)).to eq(1)


### PR DESCRIPTION
Activesupport 6.0, 6.1 and 7.0 all have `redis.with` but 7.1 uses `redis.then` but is not released yet.

https://github.com/rails/rails/blob/6-0-stable/activesupport/lib/active_support/cache/redis_cache_store.rb#L237

https://github.com/rails/rails/blob/6-1-stable/activesupport/lib/active_support/cache/redis_cache_store.rb#L238

https://github.com/rails/rails/blob/7-0-stable/activesupport/lib/active_support/cache/redis_cache_store.rb#L245
