### PR TITLE
Draft: handle all redis failures in 0.x line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+# This workflow uses actions that are not certified by GitHub.  They are
+# provided by a third-party and are governed by separate terms of service,
+# privacy policy, and support documentation.
+#
+# This workflow will install a prebuilt Ruby version, install dependencies, and
+# run tests and linters.
+name: "redis-cluster-activesupport"
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: [ '2.6', '2.7', '3.0', '3.1', '3.2', 'jruby-9.3', 'jruby-9.4' ]
+        gemfile: [ 'rails42', 'rails50', 'rails51', 'rails52', 'rails60', 'rails61', 'rails70', 'rails71' ]
+        exclude:
+          - ruby-version: '2.6'
+            gemfile: 'rails70'
+          - ruby-version: '2.6'
+            gemfile: 'rails71'
+          - ruby-version: 'jruby-9.3'
+            gemfile: 'rails70'
+          - ruby-version: 'jruby-9.3'
+            gemfile: 'rails71'
+    env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+      RAILS_ENV: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      # Add or replace dependency steps here
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ${{ matrix.ruby-version }}
+      # Add or replace test runners here
+      - name: Run tests
+        run: bundle exec rspec
+        env:
+          BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # rspec failure tracking
 .rspec_status
+gemfiles/*.lock

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 4.2.0"
+gemspec path: "../"

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 5.0.0"
+gemspec path: "../"

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 5.1.0"
+gemspec path: "../"

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 5.2.0"
+gemspec path: "../"

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 6.0.0"
+gemspec path: "../"

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 6.1.0"
+gemspec path: "../"

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 7.0.0"
+gemspec path: "../"

--- a/gemfiles/rails71.gemfile
+++ b/gemfiles/rails71.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 7.1.0"
+gemspec path: "../"

--- a/lib/active_support/cache/redis_cluster_store.rb
+++ b/lib/active_support/cache/redis_cluster_store.rb
@@ -1,3 +1,4 @@
+require "active_support/core_ext/hash" # needed for redis-activesupport in rails 7.1
 require "redis-activesupport"
 require "set"
 
@@ -13,8 +14,8 @@ module ActiveSupport
         @ignored_command_errors = ::Set.new(@options.fetch(:ignored_command_errors, DEFAULT_IGNORED_COMMAND_ERRORS))
       end
 
-      def delete_entry(key, options)
-        super
+      def delete_entry(key, options = {})
+        super(key, **options)
       rescue Redis::CommandError => error
         raise unless ignored_command_errors.include?(error.message)
         raise if raise_errors?
@@ -48,7 +49,8 @@ module ActiveSupport
         end
       end
 
-      def read_entry(key, options)
+      def read_entry(key, options = {})
+        ActiveSupport::Cache
         super
       rescue Redis::CommandError => error
         raise unless ignored_command_errors.include?(error.message)
@@ -56,7 +58,7 @@ module ActiveSupport
         nil
       end
 
-      def write_entry(key, entry, options)
+      def write_entry(key, entry, options = {})
         super
       rescue Redis::CommandError => error
         raise unless ignored_command_errors.include?(error.message)

--- a/lib/active_support/cache/redis_cluster_store.rb
+++ b/lib/active_support/cache/redis_cluster_store.rb
@@ -5,21 +5,9 @@ require "set"
 module ActiveSupport
   module Cache
     class RedisClusterStore < RedisStore
-      attr_reader :ignored_command_errors
-
-      DEFAULT_IGNORED_COMMAND_ERRORS = ["ERR Proxy error"].freeze
-
-      def initialize(*)
-        super
-        @ignored_command_errors = ::Set.new(@options.fetch(:ignored_command_errors, DEFAULT_IGNORED_COMMAND_ERRORS))
-      end
-
+      # method signature overridden slightly to support MRI >= 3.0 / JRuby >= 9.4 and Rails < 6.0
       def delete_entry(key, options = {})
         super(key, **options)
-      rescue Redis::CommandError => error
-        raise unless ignored_command_errors.include?(error.message)
-        raise if raise_errors?
-        false
       end
 
       def delete_matched(matcher, options = nil)
@@ -35,35 +23,25 @@ module ActiveSupport
         ttl = _expires_in(options)
         normalized_key = normalize_key(key, options)
         instrument(:increment, key, :amount => amount) do
-          with do |c|
-            if ttl
-              new_value, _ = c.pipelined do
+          failsafe :increment do
+            with do |c|
+              if ttl
+                new_value, _ = c.pipelined do
+                  c.incrby normalized_key, amount
+                  c.expire normalized_key, ttl
+                end
+                new_value
+              else
                 c.incrby normalized_key, amount
-                c.expire normalized_key, ttl
               end
-              new_value
-            else
-              c.incrby normalized_key, amount
             end
           end
         end
       end
 
+      # method signature overridden slightly to support MRI 3+ and Rails = 6.0
       def read_entry(key, options = {})
-        ActiveSupport::Cache
         super
-      rescue Redis::CommandError => error
-        raise unless ignored_command_errors.include?(error.message)
-        raise if raise_errors?
-        nil
-      end
-
-      def write_entry(key, entry, options = {})
-        super
-      rescue Redis::CommandError => error
-        raise unless ignored_command_errors.include?(error.message)
-        raise if raise_errors?
-        false
       end
 
       private
@@ -73,6 +51,20 @@ module ActiveSupport
           # Rack::Session           Merb                    Rails/Sinatra
           options[:expire_after] || options[:expires_in] || options[:expire_in]
         end
+      end
+
+      # Overrides failsafe method in v5.3.0 of redis-activesupport to instead rescue from the broader BaseError all
+      # Redis errors inherit from.  This is in line with how Rails handles Redis failures in the implementation of their
+      # Redis cache.
+      # @see https://github.com/redis-store/redis-activesupport/blob/v5.3.0/lib/active_support/cache/redis_store.rb#L339-L345
+      # @see https://github.com/rails/rails/blob/v6.0.6.1/activesupport/lib/active_support/cache/redis_cache_store.rb#L477-L482
+      # @see https://github.com/redis/redis-rb/blob/v4.8.1/lib/redis/errors.rb#L4-L6
+      def failsafe(method, returning: nil)
+        yield
+      rescue ::Redis::BaseError => e
+        raise if raise_errors?
+        handle_exception(exception: e, method: method, returning: returning)
+        returning
       end
     end
   end

--- a/redis-cluster-activesupport.gemspec
+++ b/redis-cluster-activesupport.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  # 7.2 drops support for cache_format_version 6.1, test when 7.2 is released
+  spec.add_dependency "activesupport", ">= 4.2", "< 7.2"
   spec.add_dependency "redis-activesupport"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "fakeredis"

--- a/redis-cluster-activesupport.gemspec
+++ b/redis-cluster-activesupport.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "redis-cluster-activesupport"
-  spec.version       = "0.3.0"
+  spec.version       = "0.4.0"
   spec.authors       = ["Garrett Thornburg"]
   spec.email         = ["film42@gmail.com"]
 

--- a/redis-cluster-activesupport.gemspec
+++ b/redis-cluster-activesupport.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   # 7.2 drops support for cache_format_version 6.1, test when 7.2 is released
   spec.add_dependency "activesupport", ">= 4.2", "< 7.2"
   spec.add_dependency "redis-activesupport"
-  spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "fakeredis"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/redis-cluster-activesupport.gemspec
+++ b/redis-cluster-activesupport.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   # 7.2 drops support for cache_format_version 6.1, test when 7.2 is released
   spec.add_dependency "activesupport", ">= 4.2", "< 7.2"
-  spec.add_dependency "redis-activesupport"
+  spec.add_dependency "redis-activesupport", "~> 5.3"
   spec.add_development_dependency "fakeredis"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require "active_support" # needed for rails 7.1
+require "active_support/core_ext/integer" # needed for rails 7.1
 require "bundler/setup"
 require "pry"
 require "redis/cluster/activesupport"


### PR DESCRIPTION
# Proposal

Create a new branch in `redis-cluster-activesupport` to track the old `0.X` line, something like `0-x-stable`, which ultimately is just tracking when this gem had its cache class inherit from [redis-activesupport](https://github.com/redis-store/redis-activesupport).  This PR is intended to be an enhancement on top of `v0.3.0`, once done I can change the branch this PR merges into.  RIght now it won't make any sense targeting master, see https://github.com/mogman1/redis-cluster-activesupport/pull/1 for what I'm actually proposing code-wise.

# Description

The `1.X` line now inherits from the more robust Redis cache that Rails maintains in ActiveSupport, but this isn't a drop-in replacement for the `redis-activesupport` class as the way it marshals the payload to write to cache changes.  Unfortunately, the way the `0.X` line handles Redis errors can still result in show-stopping errors.  The `ignored_command_errors` was intended to give a way of ignoring specific errors, however any Redis error ought to be ignorable without having to specify it.

To that end, this hands most read / write / delete logic back to `redis-activesupport`, which included a new `failsafe` method starting in `v5.3.0` that behaves similarly to what Rails does.  However, it rescues `::Redis::BaseConnectionError` rather than `::Redis::BaseError` like Rails does, so it wouldn't handle things like `::Redis::CommandError`.  In this PR I copy that `failsafe` method but instead have it rescue the base error.  

It also tweaks method signatures slightly so that newer versions of Ruby can still work in a backwards-compatible way.  I also copied over the gitlab workflows from the `1.X` line and expanded them to include Rails versions like `4.2`.

I don't expect this `0.X` line to have much in the way of further maintenance, the `1.X` versions using the newer Rails class really is the way to go.  It's just that we're still using the older versions of `redis-cluster-activesupport` and don't yet have a clean upgrade path, so having more robust Redis error handling capabilities like this would be very beneficial.