### PR TITLE
add rails 7.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ jobs:
       matrix:
         ruby-version: [ '3.2', '3.1', '3.0', '2.7', '2.6', 'jruby-9.3', 'jruby-9.4' ]
         gemfile: [ 'rails60', 'rails61', 'rails70', 'rails71' ]
+        exclude:
+          - ruby-version: '2.6'
+            gemfile: 'rails70'
+          - ruby-version: '2.6'
+            gemfile: 'rails71'
+          - ruby-version: 'jruby-9.3'
+            gemfile: 'rails70'
+          - ruby-version: 'jruby-9.3'
+            gemfile: 'rails71'
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       RAILS_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: [ '3.2', '3.1', '3.0', '2.7', '2.6', 'jruby-9.3', 'jruby-9.4' ]
-        gemfile: [ 'rails60', 'rails61' ]
+        gemfile: [ 'rails60', 'rails61', 'rails70', 'rails71' ]
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       RAILS_ENV: test

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
+gem "activesupport", "~> 7.1.0"
 # Specify your gem's dependencies in redis-cluster-activesupport.gemspec
 gemspec

--- a/gemfiles/rails70.gemfile
+++ b/gemfiles/rails70.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 7.0.0"
+gemspec path: "../"

--- a/gemfiles/rails71.gemfile
+++ b/gemfiles/rails71.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "activesupport", "~> 7.1.0"
+gemspec path: "../"

--- a/redis-cluster-activesupport.gemspec
+++ b/redis-cluster-activesupport.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 6.0", "< 7.1"
+  spec.add_dependency "activesupport", ">= 6.0", "< 7.2"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "fakeredis"
   spec.add_development_dependency "pry"

--- a/spec/active_support/cache/redis_cluster_store_spec.rb
+++ b/spec/active_support/cache/redis_cluster_store_spec.rb
@@ -3,6 +3,13 @@ require "spec_helper"
 describe ::ActiveSupport::Cache::RedisClusterStore do
   let(:options) { {} }
   let(:redis) { subject.redis }
+  let(:redis_proxy_method) do
+    if Gem::Version.new(ActiveSupport.version) >= Gem::Version.new("7.1.0")
+      :then
+    else
+      :with
+    end
+  end
 
   subject { described_class.new(*options) }
 
@@ -42,21 +49,21 @@ describe ::ActiveSupport::Cache::RedisClusterStore do
 
   describe "#write_entry" do
     it "returns false when a known error is raised" do
-      expect(redis).to receive(:with).and_raise(::Redis::CommandError, "ERR Proxy error")
+      expect(redis).to receive(redis_proxy_method).and_raise(::Redis::CommandError, "ERR Proxy error")
       expect(subject.write("test", "yolo")).to eq(false)
     end
   end
 
   describe "#read_entry" do
     it "returns false when a known error is raised" do
-      expect(redis).to receive(:with).and_raise(::Redis::CommandError, "ERR Proxy error")
+      expect(redis).to receive(redis_proxy_method).and_raise(::Redis::CommandError, "ERR Proxy error")
       expect(subject.read("test")).to eq(nil)
     end
   end
 
   describe "#delete_entry" do
     it "returns false when a known error is raised" do
-      expect(redis).to receive(:with).and_raise(::Redis::CommandError, "ERR Proxy error")
+      expect(redis).to receive(redis_proxy_method).and_raise(::Redis::CommandError, "ERR Proxy error")
       expect(subject.delete("test")).to eq(false)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "pry"
+require "logger"
 require "redis/cluster/activesupport"
 require "fakeredis/rspec"
 


### PR DESCRIPTION
### Summary

This PR updates the redis-cluster-activesupport gem to support Rails 7.1, alongside existing compatibility for Rails 6.0, 6.1, and 7.0. It ensures that applications upgrading to Rails 7.1 can continue using the custom Redis Cluster cache store without issues.

### What’s Changed
- Added a Rails version check or compatibility patch targeting Rails 7.1.
- Updated tests (and/or CI workflows) to include a rails71 test matrix entry.
- Refactored any ActiveSupport method stubs or behavior changes that differ in Rails 7.1 (for example, adjusting from `.with` to `.then` if applicable).

@film42 @skunkworker 